### PR TITLE
CI(macOS): Build bundle type plugin for OBS 28

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,17 @@ jobs:
           GIT_TAG=$(git describe --tags --always)
           PKG_SUFFIX=-${GIT_TAG}-obs${{ matrix.obs }}-macos-${{ matrix.arch }}
           set -e
+          case "${{ matrix.obs }}" in
+            27)
+              cmake_opt=()
+              ;;
+            28)
+              cmake_opt=(
+                -D MACOSX_PLUGIN_BUNDLE_TYPE=BNDL
+                -D OBS_BUNDLE_CODESIGN_IDENTITY='${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}'
+              )
+              ;;
+          esac
           cmake -S . -B build -G Ninja \
             -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -155,7 +166,8 @@ jobs:
             -DCMAKE_OSX_ARCHITECTURES=$arch \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
             -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
-            -D PKG_SUFFIX=$PKG_SUFFIX
+            -D PKG_SUFFIX=$PKG_SUFFIX \
+            "${cmake_opt[@]}"
           cmake --build build --config RelWithDebInfo
           echo "PKG_SUFFIX='$PKG_SUFFIX'" >> ci/ci_includes.generated.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,28 +176,53 @@ jobs:
           set -ex
           . ci/ci_includes.generated.sh
           cmake --install build --config RelWithDebInfo --prefix=release
-          (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
-          cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+          case ${{ matrix.obs }} in
+            27)
+              (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
+              cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+              ;;
+            28)
+              (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ MacOS/${PLUGIN_NAME})
+              cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
+              ;;
+          esac
 
       - name: Codesign
         if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           . ci/ci_includes.generated.sh
-          for dylib in release/${PLUGIN_NAME}/lib/*.dylib; do
-            test -f "$dylib" || continue
-            codesign --remove-signature "$dylib"
+          set -ex
+          case ${{ matrix.obs }} in
+            27)
+              files=(
+                $(find release/${PLUGIN_NAME}/ -name '*.dylib')
+                release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so
+              )
+              ;;
+            28)
+              files=(
+                $(find release/${PLUGIN_NAME}.plugin/ -name '*.dylib')
+                release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
+              )
+              ;;
+          esac
+          for dylib in "${files[@]}"; do
+            codesign --force --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
           done
-          for dylib in release/${PLUGIN_NAME}/*/*.{so,dylib}; do
-            test -f "$dylib" || continue
-            codesign --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
+          for dylib in "${files[@]}"; do
+            codesign -vvv --deep --strict "$dylib"
           done
 
       - name: Package
         run: |
           . ci/ci_includes.generated.sh
+          set -ex
           zipfile=$PWD/package/${PLUGIN_NAME}${PKG_SUFFIX}.zip
           mkdir package
-          (cd release/ && zip -r $zipfile $PLUGIN_NAME)
+          case ${{ matrix.obs }} in
+            27) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}) ;;
+            28) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}.plugin) ;;
+          esac
           ci/macos/install-packagesbuild.sh
           packagesbuild \
             --build-folder $PWD/package/ \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
           - obs: 27
             arch: x86_64
           - obs: 28
-            arch: arm64
+            arch: universal
     defaults:
       run:
         shell: bash
@@ -163,7 +163,7 @@ jobs:
             -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH="$PWD/release/" \
-            -DCMAKE_OSX_ARCHITECTURES=$arch \
+            -DCMAKE_OSX_ARCHITECTURES=${arch/#universal/x86_64;arm64} \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
             -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
             -D PKG_SUFFIX=$PKG_SUFFIX \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   artifactName: ${{ contains(github.ref_name, '/') && 'artifact' || github.ref_name }}
+  qt: false
 
 jobs:
   linux_build:
@@ -40,6 +41,7 @@ jobs:
         with:
           obs: ${{ matrix.obs }}
           verbose: true
+          qt: ${{ env.qt }}
 
       - name: Build plugin
         run: |
@@ -138,6 +140,7 @@ jobs:
           arch: ${{ matrix.arch }}
           obs: ${{ matrix.obs }}
           verbose: true
+          qt: ${{ env.qt }}
 
       - name: Build plugin
         run: |
@@ -275,6 +278,7 @@ jobs:
         uses: norihiro/obs-studio-devel-action@v1-beta
         with:
           obs: ${{ matrix.obs }}
+          qt: ${{ env.qt }}
 
       - name: Build plugin
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - '**.md'
     branches:
-      - master
+      - main
 
 env:
   artifactName: ${{ contains(github.ref_name, '/') && 'artifact' || github.ref_name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ if(APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fvisibility=default")
 
 	set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES PREFIX "")
+	set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
+	set(MACOSX_PLUGIN_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
+	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
 
 	configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,8 @@ if(APPLE)
 	set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
 	set(MACOSX_PLUGIN_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
 	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
-
-	configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)
 endif()
 
 setup_plugin_target(${CMAKE_PROJECT_NAME})
+
+configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)

--- a/ci/macos/change-rpath.sh
+++ b/ci/macos/change-rpath.sh
@@ -21,7 +21,9 @@ set -e
 function copy_local_dylib
 {
 	local dylib
-	otool -L $1 | awk '/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}' |
+	t=$(mktemp)
+	otool -L $1 > $t
+	awk '/^	\/usr\/local\/(opt|Cellar)\/.*\.dylib/{print $1}' $t |
 	while read -r dylib; do
 		echo "Changing dependency $1 -> $dylib"
 		local b=$(basename $dylib)

--- a/ci/macos/install-packagesbuild.sh
+++ b/ci/macos/install-packagesbuild.sh
@@ -6,7 +6,7 @@ if which packagesbuild; then
 	exit 0
 fi
 
-packages_url='http://s.sudre.free.fr/Software/files/Packages.dmg'
+packages_url='http://www.nagater.net/obs-studio/Packages.dmg'
 packages_hash='6afdd25386295974dad8f078b8f1e41cabebd08e72d970bf92f707c7e48b16c9'
 
 for ((retry=5; retry>0; retry--)); do

--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -110,6 +110,32 @@ if(OS_MACOS)
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH OFF)
 
 	function(setup_plugin_target target)
+		if(NOT DEFINED MACOSX_PLUGIN_GUI_IDENTIFIER)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_GUI_IDENTIFIER' set, but is required to build plugin bundles on macOS - example: 'com.yourname.pluginname'"
+				)
+		endif()
+
+		if(NOT DEFINED MACOSX_PLUGIN_BUNDLE_VERSION)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_BUNDLE_VERSION' set, but is required to build plugin bundles on macOS - example: '25'"
+				)
+		endif()
+
+		if(NOT DEFINED MACOSX_PLUGIN_SHORT_VERSION_STRING)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_SHORT_VERSION_STRING' set, but is required to build plugin bundles on macOS - example: '1.0.2'"
+				)
+		endif()
+
+		set(MACOSX_PLUGIN_BUNDLE_NAME "${target}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_BUNDLE_VERSION "${MACOSX_BUNDLE_BUNDLE_VERSION}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_SHORT_VERSION_STRING "${MACOSX_BUNDLE_SHORT_VERSION_STRING}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_EXECUTABLE_NAME "${target}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_BUNDLE_TYPE "BNDL" PARENT_SCOPE)
 
 		install(
 			TARGETS ${target}

--- a/cmake/bundle/macos/Plugin-Info.plist.in
+++ b/cmake/bundle/macos/Plugin-Info.plist.in
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_PLUGIN_GUI_IDENTIFIER}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_PLUGIN_SHORT_VERSION_STRING}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_PLUGIN_EXECUTABLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_TYPE}</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.13</string>
+</dict>
+</plist>

--- a/cmake/bundle/macos/entitlements.plist
+++ b/cmake/bundle/macos/entitlements.plist
@@ -1,0 +1,17 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.device.camera</key>
+        <true/>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+        <!-- Allows @executable_path to load libaries from within the .app bundle. -->
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true/>
+    </dict>
+</plist>

--- a/installer/installer-macOS.pkgproj.in
+++ b/installer/installer-macOS.pkgproj.in
@@ -63,7 +63,7 @@
 															<key>GID</key>
 															<integer>80</integer>
 															<key>PATH</key>
-															<string>../@RELATIVE_INSTALL_PATH@/@CMAKE_PROJECT_NAME@</string>
+															<string>../@RELATIVE_INSTALL_PATH@/@CMAKE_PROJECT_NAME@@FIRST_DIR_SUFFIX@</string>
 															<key>PATH_TYPE</key>
 															<integer>1</integer>
 															<key>PERMISSIONS</key>


### PR DESCRIPTION


### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->
- CI(macOS): Build bundle type plugin
  - CI(macOS): Detect error of otool
  - CI(macOS): Download Packages.dmg from my web server
- CI(macOS): Build universal binary instead of arm64 for OBS 28.
- CI(macOS, Linux): Disable downloading Qt library


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
